### PR TITLE
Fixed node 6 deprecation warnings

### DIFF
--- a/src/city.cc
+++ b/src/city.cc
@@ -25,8 +25,7 @@ void City::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("City").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("City").ToLocalChecked(), tpl->GetFunction());

--- a/src/city6.cc
+++ b/src/city6.cc
@@ -27,8 +27,7 @@ void City6::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("City6").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("City6").ToLocalChecked(), tpl->GetFunction());

--- a/src/country.cc
+++ b/src/country.cc
@@ -26,8 +26,7 @@ void Country::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("Country").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("Country").ToLocalChecked(), tpl->GetFunction());

--- a/src/country6.cc
+++ b/src/country6.cc
@@ -26,8 +26,7 @@ void Country6::Init(v8::Local<v8::Object> exports) {
     tpl->SetClassName(Nan::New("Country6").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-        Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+    Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
     constructor.Reset(tpl->GetFunction());
     exports->Set(Nan::New("Country6").ToLocalChecked(), tpl->GetFunction());

--- a/src/netspeed.cc
+++ b/src/netspeed.cc
@@ -26,8 +26,7 @@ void NetSpeed::Init(v8::Local<v8::Object> exports) {
     tpl->SetClassName(Nan::New("NetSpeed").ToLocalChecked());
     tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-    tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-        Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+    Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
     constructor.Reset(tpl->GetFunction());
     exports->Set(Nan::New("NetSpeed").ToLocalChecked(), tpl->GetFunction());

--- a/src/netspeedcell.cc
+++ b/src/netspeedcell.cc
@@ -26,8 +26,7 @@ void NetSpeedCell::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("NetSpeedCell").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("NetSpeedCell").ToLocalChecked(), tpl->GetFunction());

--- a/src/org.cc
+++ b/src/org.cc
@@ -25,8 +25,7 @@ void Org::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("Org").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("Org").ToLocalChecked(), tpl->GetFunction());;;

--- a/src/region.cc
+++ b/src/region.cc
@@ -27,8 +27,7 @@ void Region::Init(v8::Local<v8::Object> exports) {
   tpl->SetClassName(Nan::New("Region").ToLocalChecked());
   tpl->InstanceTemplate()->SetInternalFieldCount(1);
 
-  tpl->PrototypeTemplate()->Set(Nan::New("lookupSync").ToLocalChecked(),
-      Nan::New<v8::FunctionTemplate>(lookupSync)->GetFunction());
+  Nan::SetPrototypeMethod(tpl, "lookupSync", lookupSync);
 
   constructor.Reset(tpl->GetFunction());
   exports->Set(Nan::New("Region").ToLocalChecked(), tpl->GetFunction());


### PR DESCRIPTION
Fixed the node 6 deprecation warnings generated when requiring the module

```
(node) v8::ObjectTemplate::Set() with non-primitive values is deprecated
(node) and will stop working in the next major release.

==== JS stack trace =========================================

Security context: 0x3e018a6c9e59 <JS Object>#0#
    1: .node [module.js:568] [pc=0x12f4cbb4d404] (this=0x3f58ee0d1af9 <an Object with map 0x1596e631a261>#1#,module=0x3f58ee0f2441 <a Module with map 0x1596e631a839>#2#,filename=0x3f58ee0f2371 <String[56]: /Users/shankar/workspace/GeoIP/build/Release/native.node>)
    2: load [module.js:458] [pc=0x12f4cbb35772] (this=0x3f58ee0f2441 <a Module with map 0x1596e631a839>#2#,filename=0x3f58ee0f2371 <String[56]: /Users/shankar/workspace/GeoIP/build/Release/native.node>)
    3: tryModuleLoad(aka tryModuleLoad) [module.js:417] [pc=0x12f4cbb3529d] (this=0x3e018a604189 <undefined>,module=0x3f58ee0f2441 <a Module with map 0x1596e631a839>#2#,filename=0x3f58ee0f2371 <String[56]: /Users/shankar/workspace/GeoIP/build/Release/native.node>)
    4: _load [module.js:409] [pc=0x12f4cbb30e82] (this=0x3f58ee09d249 <JS Function Module (SharedFunctionInfo 0x389f9ab2db71)>#3#,request=0x3f58ee0f1aa9 <String[56]: /Users/shankar/workspace/GeoIP/build/Release/native.node>,parent=0x3f58ee0e3a39 <a Module with map 0x1596e631a839>#4#,isMain=0x3e018a604299 <false>)
    5: require [module.js:468] [pc=0x12f4cbb3e953] (this=0x3f58ee0e3a39 <a Module with map 0x1596e631a839>#4#,path=0x3f58ee0f1aa9 <String[56]: /Users/shankar/workspace/GeoIP/build/Release/native.node>)
    6: require(aka require) [internal/module.js:20] [pc=0x12f4cbb3e686] (this=0x3e018a604189 <undefined>,path=0x3f58ee0f1aa9 <String[56]: /Users/shankar/workspace/GeoIP/build/Release/native.node>)
    7: bindings [/Users/shankar/workspace/GeoIP/node_modules/bindings/bindings.js:76] [pc=0x12f4cbb476b6] (this=0x3e018a6e1601 <JS Global Object>#5#,opts=0x389f9ab60871 <String[11]: native.node>)
    8: /* anonymous */ [/Users/shankar/workspace/GeoIP/index.js:4] [pc=0x12f4cbb44d91] (this=0x3f58ee0dc391 <an Object with map 0x21c05c907ac1>#6#,exports=0x3f58ee0dc391 <an Object with map 0x21c05c907ac1>#6#,require=0x3f58ee0de3e1 <JS Function require (SharedFunctionInfo 0x389f9ab5c841)>#7#,module=0x3f58ee0dc309 <a Module with map 0x1596e631a839>#8#,__filename=0x3f58ee0dc1f9 <String[39]: /Users/shankar/workspace/GeoIP/index.js>,__dirname=0x3f58ee0de349 <String[30]: /Users/shankar/workspace/GeoIP>)
    9: _compile [module.js:541] [pc=0x12f4cbb3ddb0] (this=0x3f58ee0dc309 <a Module with map 0x1596e631a839>#8#,content=0x3f58ee0dd661 <String[996]\: var path  = require('path'),\n    read  = require('fs').readFileSync;\n\nvar binding = require('bindings')('native.node');\n\nvar version  = JSON.parse(read(path.resolve(__dirname, './package.json'))).version;\n\n// Native classes\nexports.native = binding;\n\n// Libraries\nexports.NetSpeedCell = require('./lib/netspeedcell');\nexports.NetSpeed     = require('./lib/netspeed');\nexports.Country6     = require('./lib/country6');\nexports.Country      = require('./lib/country');\nexports.Region       = require('./lib/region');\nexports.City6        = require('./lib/city6');\nexports.City         = require('./lib/city');\nexports.Org          = require('./lib/org');\n\n// Utilities\nexports.check       = binding.check;\nexports.isString    = binding.isString;\nexports.utils       = {\n    check: binding.check,\n    isString: binding.isString\n}\n\n// Versions\nexports.version  = 'v' + version;\nexports.libgeoip = 'v' + binding.libgeoip;\nexports.versions = {\n    'geoip': version,\n    'libgeoip': binding.libgeoip\n};\n>,filename=0x3f58ee0dc1f9 <String[39]: /Users/shankar/workspace/GeoIP/index.js>)
   10: .js [module.js:550] [pc=0x12f4cbb36d6b] (this=0x3f58ee0d1af9 <an Object with map 0x1596e631a261>#1#,module=0x3f58ee0dc309 <a Module with map 0x1596e631a839>#8#,filename=0x3f58ee0dc1f9 <String[39]: /Users/shankar/workspace/GeoIP/index.js>)
   11: load [module.js:458] [pc=0x12f4cbb35772] (this=0x3f58ee0dc309 <a Module with map 0x1596e631a839>#8#,filename=0x3f58ee0dc1f9 <String[39]: /Users/shankar/workspace/GeoIP/index.js>)
   12: tryModuleLoad(aka tryModuleLoad) [module.js:417] [pc=0x12f4cbb3529d] (this=0x3e018a604189 <undefined>,module=0x3f58ee0dc309 <a Module with map 0x1596e631a839>#8#,filename=0x3f58ee0dc1f9 <String[39]: /Users/shankar/workspace/GeoIP/index.js>)
```
